### PR TITLE
Monkey patches Search model's save function to be a no-op

### DIFF
--- a/config/initializers/monkeypatch_do_not_save_searches.rb
+++ b/config/initializers/monkeypatch_do_not_save_searches.rb
@@ -1,0 +1,5 @@
+class Search < ActiveRecord::Base
+  def save
+    false
+  end
+end


### PR DESCRIPTION
The Search model comes from Blacklight, which saves all searches by default, which creates large databases that we do not use, but cause problems when they get too big. This monkey patches Search#save to do nothing.

Closes #272. Finally, geez.